### PR TITLE
Updates cAdvisor image to v0.49.2

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -54,7 +54,7 @@ services:
 
   cadvisor:
     restart: unless-stopped
-    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    image: gcr.io/cadvisor/cadvisor:v0.49.2
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /:/rootfs:ro,rslave


### PR DESCRIPTION
Bumps the container image version for cAdvisor to the latest patch release to incorporate recent bug fixes and improvements.