### PR TITLE
BCE-6312: Dynamic DNS for AWS

### DIFF
--- a/default.env
+++ b/default.env
@@ -1,5 +1,5 @@
 # Copy this to .env and adjust
-COMPOSE_FILE=traefik-cf.yml:prometheus.yml:promtail.yml
+COMPOSE_FILE=traefik-aws.yml:prometheus.yml:promtail.yml
 
 # Secure web proxy
 DOMAIN=example.com
@@ -37,9 +37,9 @@ DDNS_TAG=v2
 CNAME_LIST=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
-AWS_REGION=
+AWS_REGION=us-east-1
 PYTHON_DNS_TAG=3.12-alpine
-TTL=300
+TTL=1
 
 # Used by ethd update - please do not adjust
 ENV_VERSION=3

--- a/default.env
+++ b/default.env
@@ -33,5 +33,12 @@ IPV6=false
 TRAEFIK_TAG=v3.1
 DDNS_TAG=v2
 
+# new variables for Traefik-AWS
+CNAME_LIST=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=
+PYTHON_DNS_TAG=3.12-alpine
+
 # Used by ethd update - please do not adjust
 ENV_VERSION=3

--- a/default.env
+++ b/default.env
@@ -39,6 +39,7 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=
 PYTHON_DNS_TAG=3.12-alpine
+TTL=300
 
 # Used by ethd update - please do not adjust
 ENV_VERSION=3

--- a/dns/Dockerfile
+++ b/dns/Dockerfile
@@ -1,8 +1,8 @@
+ARG DOCKER_TAG=3.12-alpine
 FROM python:${DOCKER_TAG}
 
 WORKDIR /app
 
-# Minimal dependencies
 RUN pip install --no-cache-dir boto3 requests tenacity
 
 COPY app/updater.py .

--- a/dns/Dockerfile
+++ b/dns/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:${DOCKER_TAG}
+
+WORKDIR /app
+
+# Minimal dependencies
+RUN pip install --no-cache-dir boto3 requests tenacity
+
+COPY app/updater.py .
+
+CMD ["python", "updater.py"]

--- a/dns/app/updater.py
+++ b/dns/app/updater.py
@@ -1,0 +1,153 @@
+import os
+import json
+import logging
+import time
+import requests
+from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_exception_type
+import boto3
+from botocore.exceptions import ClientError
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger("dns-updater")
+
+# Load environment variables
+HOSTED_ZONE_ID = os.environ["HOSTED_ZONE_ID"]
+A_RECORD_NAME = os.environ["A_RECORD_NAME"]
+CNAME_LIST = os.getenv("CNAME_LIST", "")
+TTL = int(os.getenv("TTL", 300))
+SLEEP = int(os.getenv("SLEEP", 300))
+
+
+# Parse CNAME targets
+CNAME_TARGETS = [c.strip() for c in CNAME_LIST.split(",") if c.strip()]
+
+def check_credentials():
+    env_creds = os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY")
+    profile = os.getenv("AWS_PROFILE")
+    credentials_path = "/root/.aws/credentials"
+
+    if env_creds:
+        logger.info("Using AWS credentials from environment variables.")
+    elif profile and os.path.exists(credentials_path):
+        logger.info(f"Using AWS profile '{profile}' from {credentials_path}")
+    elif os.path.exists(credentials_path):
+        logger.info(f"Using default AWS profile from {credentials_path}")
+    else:
+        raise RuntimeError("No valid AWS credentials found (env vars or ~/.aws/credentials)")
+
+check_credentials()
+session = boto3.session.Session()
+route53 = session.client("route53")
+
+def validate_ipv4(ip):
+    parts = ip.split(".")
+    return len(parts) == 4 and all(part.isdigit() and 0 <= int(part) <= 255 for part in parts)
+
+
+@retry(wait=wait_exponential(multiplier=1, min=2, max=10), stop=stop_after_attempt(5),
+       retry=retry_if_exception_type(requests.RequestException))
+def get_external_ip():
+    ip_services = [
+        "https://checkip.amazonaws.com",
+        "https://api64.ipify.org",
+        "https://ipinfo.io/ip",
+        "https://icanhazip.com",
+        "https://ifconfig.me",
+        "https://ident.me",
+        "https://ipecho.net/plain",
+        "https://wtfismyip.com/text",
+        "https://bot.whatismyipaddress.com",
+        "https://myexternalip.com/raw",
+        "http://whatismyip.akamai.com",
+        "http://ip.42.pl/raw",
+        "https://ip.seeip.org",
+        "https://ip.tyk.nu",
+        "https://api.my-ip.io/ip",
+        "https://ipv4.icanhazip.com",
+        "https://ipwho.is/?format=text"
+    ]
+
+    for url in ip_services:
+        try:
+            resp = requests.get(url, timeout=3)
+            if resp.ok:
+                text = resp.text.strip()
+                ip = text.split()[0]
+                if validate_ipv4(ip):
+                    logger.info(f"Got external IP from {url}: {ip}")
+                    return ip
+                else:
+                    logger.warning(f"Invalid IP format from {url}: {ip}")
+        except Exception as e:
+            logger.debug(f"Failed to get IP from {url}: {e}")
+
+    raise requests.RequestException("Unable to fetch external IP from any source")
+
+
+def record_exists(name, rtype, value):
+    try:
+        resp = route53.list_resource_record_sets(
+            HostedZoneId=HOSTED_ZONE_ID,
+            StartRecordName=name,
+            StartRecordType=rtype,
+            MaxItems="1"
+        )
+        records = resp.get("ResourceRecordSets", [])
+        if records and records[0]["Name"] == name and records[0]["Type"] == rtype:
+            existing_values = [r["Value"] for r in records[0]["ResourceRecords"]]
+            return value in existing_values
+    except ClientError as e:
+        logger.error(f"Error checking existing record: {e}")
+    return False
+
+
+def upsert_record(name, rtype, value):
+    change = {
+        "Action": "UPSERT",
+        "ResourceRecordSet": {
+            "Name": name,
+            "Type": rtype,
+            "TTL": TTL,
+            "ResourceRecords": [{"Value": value}]
+        }
+    }
+    try:
+        route53.change_resource_record_sets(
+            HostedZoneId=HOSTED_ZONE_ID,
+            ChangeBatch={
+                "Comment": f"Auto-updated {rtype} record for {name}",
+                "Changes": [change]
+            }
+        )
+        logger.info(f"Upserted {rtype} record: {name} -> {value}")
+    except ClientError as e:
+        logger.error(f"Failed to upsert {rtype} record {name}: {e}")
+
+
+def run():
+    while True:
+        try:
+            ip = get_external_ip()
+            fqdn = A_RECORD_NAME if A_RECORD_NAME.endswith('.') else A_RECORD_NAME + '.'
+
+            if not record_exists(fqdn, "A", ip):
+                upsert_record(fqdn, "A", ip)
+            else:
+                logger.info(f"A record {fqdn} already up-to-date with IP {ip}")
+
+            for cname in CNAME_TARGETS:
+                cname_fqdn = cname if cname.endswith('.') else cname + '.'
+                if not record_exists(cname_fqdn, "CNAME", fqdn):
+                    upsert_record(cname_fqdn, "CNAME", fqdn)
+                else:
+                    logger.info(f"CNAME {cname_fqdn} already points to {fqdn}")
+
+        except Exception as e:
+            logger.error(f"Error during update cycle: {e}")
+
+        logger.info(f"Sleeping {SLEEP} seconds")
+        time.sleep(SLEEP)
+
+
+if __name__ == "__main__":
+    run()

--- a/dns/app/updater.py
+++ b/dns/app/updater.py
@@ -11,7 +11,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(me
 logger = logging.getLogger("dns-updater")
 
 # Load environment variables
-HOSTED_ZONE_ID = os.environ["HOSTED_ZONE_ID"]
+HOSTED_ZONE_ID = os.environ["AWS_HOSTED_ZONE_ID"]
 A_RECORD_NAME = os.environ["A_RECORD_NAME"]
 CNAME_LIST = os.getenv("CNAME_LIST", "")
 TTL = int(os.getenv("TTL", 300))

--- a/traefik-aws.yml
+++ b/traefik-aws.yml
@@ -65,7 +65,7 @@ services:
       - AWS_PROFILE=${AWS_PROFILE:-}
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - AWS_HOSTED_ZONE_ID=${HOSTED_ZONE_ID}
-      - A_RECORD_NAME=${DOMAIN}
+      - A_RECORD_NAME=${DDNS_SUBDOMAIN}.${DOMAIN}
       - CNAME_LIST=${CNAME_LIST:-}
       - TTL=${TTL:-300}
     volumes:

--- a/traefik-aws.yml
+++ b/traefik-aws.yml
@@ -8,12 +8,7 @@ x-logging: &logging
 
 services:
   traefik:
-    image: traefik-aws
-    pull_policy: never
-    build:
-      context: ./traefik
-      args:
-        - DOCKER_TAG=${TRAEFIK_TAG:-latest}
+    image: traefik:${TRAEFIK_TAG}
     restart: "unless-stopped"
     command:
 #      - --accesslog=true
@@ -45,7 +40,9 @@ services:
       - ${HOST_IP:-}:${TRAEFIK_WEB_PORT}:${TRAEFIK_WEB_PORT}/tcp
       - ${HOST_IP:-}:${TRAEFIK_WEB_HTTP_PORT}:${TRAEFIK_WEB_HTTP_PORT}/tcp
     environment:
-      - AWS_PROFILE=${AWS_PROFILE}
+      - AWS_PROFILE=${AWS_PROFILE:-}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_HOSTED_ZONE_ID=${AWS_HOSTED_ZONE_ID}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -53,6 +50,25 @@ services:
       - ~/.aws:/root/.aws:ro
       - ./traefik/configs:/configs:ro
       - /etc/localtime:/etc/localtime:ro
+    <<: *logging
+
+  dns:
+    image: dns-aws
+    build:
+      context: ./dns
+      args:
+        - DOCKER_TAG=${PYTHON_DNS_TAG:-latest}
+    restart: "unless-stopped"
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_PROFILE=${AWS_PROFILE:-}
+      - AWS_REGION=${AWS_REGION:-us-east-1}
+      - AWS_HOSTED_ZONE_ID=${HOSTED_ZONE_ID}
+      - A_RECORD_NAME=${DOMAIN}
+      - CNAME_LIST=${CNAME_LIST:-}
+    volumes:
+      - ~/.aws:/root/.aws:ro
     <<: *logging
 
 volumes:

--- a/traefik-aws.yml
+++ b/traefik-aws.yml
@@ -67,6 +67,7 @@ services:
       - AWS_HOSTED_ZONE_ID=${HOSTED_ZONE_ID}
       - A_RECORD_NAME=${DOMAIN}
       - CNAME_LIST=${CNAME_LIST:-}
+      - TTL=${TTL:-300}
     volumes:
       - ~/.aws:/root/.aws:ro
     <<: *logging


### PR DESCRIPTION
ETH Update test fails because the creation of a docker image at runtime
```
WARNING: Some service image(s) must be built from source by running:
    docker compose build dns
1 error occurred:
	* Error response from daemon: pull access denied for dns-aws, repository does not exist or may require 'docker login': denied: requested access to the resource is denied


./ethd terminated with exit code 1 on line 137
This happened during ./ethd update
```


Confirmed that it works
```
dns-1       | 2025-08-11 23:27:44,339 [INFO] Using AWS profile 'bcedev' from /root/.aws/credentials
dns-1       | 2025-08-11 23:27:44,398 [INFO] Found credentials in shared credentials file: ~/.aws/credentials
dns-1       | 2025-08-11 23:27:45,284 [INFO] Got external IP from https://checkip.amazonaws.com/: 44.223.143.33
dns-1       | 2025-08-11 23:27:45,444 [INFO] A record enrique.dev.bci.glxy.com. already up-to-date with IP 44.223.143.33
dns-1       | 2025-08-11 23:27:45,546 [INFO] Upserted CNAME record: enrique-cl.dev.bci.glxy.com. -> enrique.dev.bci.glxy.com.
dns-1       | 2025-08-11 23:27:45,547 [INFO] Sleeping 300 seconds
```