### PR TITLE
node-exporter uses host networking

### DIFF
--- a/default.env
+++ b/default.env
@@ -27,6 +27,12 @@ TRAEFIK_WEB_PORT=443
 TRAEFIK_WEB_HTTP_PORT=80
 TRAEFIK_INSECURE_API=false # Default if not provided
 
+# Node exporter is direct on host, make sure it doesn't conflict
+# If ufw is "in front of" Docker, make sure to allow this traffic
+# sudo ufw allow from 172.16.0.0/12 to any port 9199 comment "node-exporter from docker"
+# sudo ufw allow from 192.168.0.0/16 to any port 9199 comment "node-exporter from docker"
+NODE_EXPORTER_PORT=9199
+
 HOST_IP=
 IPV6=false
 
@@ -42,4 +48,4 @@ PYTHON_DNS_TAG=3.12-alpine
 TTL=1
 
 # Used by ethd update - please do not adjust
-ENV_VERSION=3
+ENV_VERSION=4

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -27,6 +27,8 @@ services:
       - --web.console.templates=/usr/share/prometheus/consoles
       - --log.level=${LOG_LEVEL:-info}
     <<: *logging
+    extra_hosts:  # So we can scrape node-exporter
+      - "host.docker.internal:host-gateway"
     depends_on:
       - node-exporter
       - cadvisor
@@ -43,10 +45,13 @@ services:
       - '--path.rootfs=/host'
       - '--path.procfs=/host/proc'
       - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|run|var/lib/docker/.+)($$|/)'
+      - '--collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run|var/lib/docker/.+)($$|/)'
       - '--no-collector.ipvs'
       - '--collector.textfile.directory=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/home/}'
+      - '--collector.netdev.device-exclude=^(veth.*|docker.*|br-.*)$'
+      - '--web.listen-address=0.0.0.0:${NODE_EXPORTER_PORT:-9199}'
     pid: host
+    network_mode: host  # See all network interfaces
     restart: unless-stopped
     environment:
       - NODE_EXPORTER_COLLECTOR_MOUNT_PATH=${NODE_EXPORTER_COLLECTOR_MOUNT_PATH:-/dev/null}
@@ -60,7 +65,8 @@ services:
     labels:
       - metrics.scrape=true
       - metrics.path=/metrics
-      - metrics.port=9100
+      - metrics.host=host.docker.internal
+      - metrics.port=${NODE_EXPORTER_PORT:-9199}
     <<: *logging
 
   cadvisor:

--- a/prometheus/base-config.yml
+++ b/prometheus/base-config.yml
@@ -33,35 +33,43 @@ scrape_configs:
         target_label: project
       # Optional: override metrics_path using metrics.path (default is /metrics)
       - action: replace
-        regex: (.+)
         source_labels:
           - __meta_docker_container_label_metrics_path
+        regex: (.+)
         target_label: __metrics_path__
       # Required: Configure the HTTP host and port to scrape using metrics.port
       - action: replace
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
         source_labels:
           - __address__
           - __meta_docker_container_label_metrics_port
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      # Optional: metrics.host overrides __address__
+      - action: replace
+        source_labels:
+          - __meta_docker_container_label_metrics_host
+          - __meta_docker_container_label_metrics_port
+        regex: (.+);(\d+)
+        replacement: $1:$2
         target_label: __address__
       # Optional: Sets Prometheus 'job' label using metrics.job, otherwise uses the compose service name
       - action: replace
-        regex: (.+)
         source_labels:
           - __meta_docker_container_label_metrics_job
+        regex: (.+)
         target_label: job
       # Optional: override the global scrape interval using metrics.interval
       - action: replace
-        regex: (.+)
         source_labels:
           - __meta_docker_container_label_metrics_interval
+        regex: (.+)
         target_label: __scrape_interval__
       # Optional: Sets Prometheus 'instance' label using metrics.instance, otherwise uses IP:PORT
       - action: replace
-        regex: (.+)
         source_labels:
           - __meta_docker_container_label_metrics_instance
+        regex: (.+)
         target_label: instance
       - source_labels: [__meta_docker_container_label_metrics_network]
         target_label: network


### PR DESCRIPTION
Node exporters runs in host network mode so it can see physical interfaces

Port is configurable, as this may conflict with existing processes

Prometheus scrapes `host.docker.internal` to get to the host

Note this needs a ufw rule change if ufw is "in front of" docker

https://galaxydig.atlassian.net/browse/BCE-7259