### PR TITLE
Bump default Traefik tag to 3.5

### DIFF
--- a/default.env
+++ b/default.env
@@ -30,7 +30,7 @@ TRAEFIK_INSECURE_API=false # Default if not provided
 HOST_IP=
 IPV6=false
 
-TRAEFIK_TAG=v3.1
+TRAEFIK_TAG=v3.5
 DDNS_TAG=v2
 
 # new variables for Traefik-AWS


### PR DESCRIPTION
Traefik 3.1 is a bit long in the tooth; default to current stable release