### PR TITLE
Add .gitignore to traefik-utils/configs

### DIFF
--- a/traefik-utils/configs/.gitignore
+++ b/traefik-utils/configs/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!tls.toml


### PR DESCRIPTION
This directory was never meant for user-supplied configs. But it *can* and has been used that way, which means we need a .gitignore