### PR TITLE
Use a wildcard for dependabot pip and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "*"
     schedule:
       interval: "weekly"
     groups:
@@ -14,7 +15,8 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
-    directory: "/"
+    directories:
+      - "*"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
As otherwise it won't find relevant files in subdirectories