### PR TITLE
Update cadvisor

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -71,7 +71,7 @@ services:
 
   cadvisor:
     restart: unless-stopped
-    image: gcr.io/cadvisor/cadvisor:v0.49.2
+    image: ghcr.io/google/cadvisor:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /:/rootfs:ro,rslave


### PR DESCRIPTION
cadvisor `0.54.0` supports the new `overlayfs` Storage driver in Docker 29.x and later

The repo for cadvisor changed to ghcr.io. Also change the tag to `latest` with the repo change